### PR TITLE
Add EquoIDE configured to auto import via Gradle Buildship

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,12 @@
 plugins {
     id 'java'
     id 'eclipse'
+    id 'dev.equo.ide' version '1.0.1'
+}
+
+equoIde { // launch with ./gradlew equoIde
+    jdt()
+    gradleBuildship().autoImport('.')
 }
 
 group 'com.kousenit'


### PR DESCRIPTION
I enjoyed your video on importing a Gradle project into Eclipse. Another way is to apply this plugin and run `./gradlew equoIde`.

EquoIDE is a project that uses Eclipse to generate your IDE as a built artifact - every plugin and configuration action programmatically repeatable and described in your build file. `./gradlew equoIde --clean` if your state ever gets out of whack.

https://github.com/equodev/equo-ide